### PR TITLE
Remove unnecessary space before semester title.

### DIFF
--- a/templates/semester_start.mustache
+++ b/templates/semester_start.mustache
@@ -1,5 +1,5 @@
 <fieldset class="semester{{#expanded}} expanded {{/expanded}} {{#empty}} empty {{/empty}}  {{{semestercode}}}" data-id="{{{semestercode}}}">
     <legend>
-        <div class="imgbox"></div> {{{semestertitle}}}
+        <div class="imgbox"></div>{{{semestertitle}}}
     </legend>
     <div class="expandablebox">


### PR DESCRIPTION
I just noticed this. That space is not needed there and breaks same indent when you are leaving the fieldset lines away.
Best,
Luca