### PR TITLE
Support filter in course fullname and summary.

### DIFF
--- a/block_semester_sortierung.php
+++ b/block_semester_sortierung.php
@@ -130,6 +130,10 @@ class block_semester_sortierung extends block_base {
                 $courses[$c->id]->lastaccess = 0;
             }
 
+            // Support filter in fullname and summary.
+            $courses[$c->id]->fullname = format_string($courses[$c->id]->fullname);
+            $courses[$c->id]->summary = format_string($courses[$c->id]->summary);
+
             // Use the loop to load unread forum posts!
             if ($this->config->showunreadforumposts == 1) {
                 $unreadposts = forum_tp_get_course_unread_posts($USER->id, $c->id);
@@ -142,7 +146,6 @@ class block_semester_sortierung extends block_base {
                 }
             }
         }
-
 
         // Add the semester to each course.
         $courses = block_semester_sortierung_fill_course_semester($courses, $this->config);


### PR DESCRIPTION
In our place we do use the multilang2 filter a lot, even in course fullnames.
Unfortunately, blocks_semester_sortierung doesn't apply the filters to fullname and summary.
A course fullname of "{mlang de}Statik und Kraftübertragung im Fahrzeug{mlang}{mlang fr}Statique/transmission des forces du véhicule{mlang}{mlang en}Statik und Kraftübertragung im Fahrzeug{mlang}{mlang it}{mlang}{mlang es}{mlang} (BTA2150) 19/20" is perfectly valid and with the multilang2 filter displays nicely.
It would be great if you could accept this pull request.
Best,
Luca